### PR TITLE
Fix for messages.get(); would sometimes make a POST request

### DIFF
--- a/lib/2.0/index.js
+++ b/lib/2.0/index.js
@@ -28,7 +28,6 @@ module.exports = (function(settings) {
         post: _callService.post.bind(_callService, resource),
         delete: _callService.delete.bind(_callService, resource),
 
-        //Connect Tokens
         connect_tokens(token) {
 
           if (!account_id) {
@@ -44,7 +43,6 @@ module.exports = (function(settings) {
           }
         },
 
-        //Contacts
         contacts(email) {
 
           if (!account_id) {
@@ -56,7 +54,6 @@ module.exports = (function(settings) {
           return {
             get: _callService.get.bind(_callService, resource),
 
-            //Files
             files() {
 
               if (!email) {
@@ -68,7 +65,6 @@ module.exports = (function(settings) {
               }
             },
 
-            //Messages
             messages() {
 
               if (!email) {
@@ -80,7 +76,6 @@ module.exports = (function(settings) {
               }
             },
 
-            //Threads
             threads() {
 
               if (!email) {
@@ -94,7 +89,6 @@ module.exports = (function(settings) {
           }
         },
 
-        //Connect Tokens
         email_addresses(email) {
 
           if (!account_id) {
@@ -110,7 +104,6 @@ module.exports = (function(settings) {
           }
         },
 
-        //Files
         files(file_id) {
 
           if (!account_id) {
@@ -143,7 +136,6 @@ module.exports = (function(settings) {
             },
 
 
-            //Related
             related() {
 
               if (!file_id) {
@@ -159,7 +151,6 @@ module.exports = (function(settings) {
           }
         },
 
-        //Messages
         messages(message_id) {
 
           if (!account_id) {
@@ -173,7 +164,6 @@ module.exports = (function(settings) {
             post: _callService.post.bind(_callService, resource),
             delete: _callService.delete.bind(_callService, resource),
 
-            //Body
             body() {
 
               if (!message_id) {
@@ -187,7 +177,6 @@ module.exports = (function(settings) {
               }
             },
 
-            //Flags
             flags() {
 
               if (!message_id) {
@@ -202,7 +191,6 @@ module.exports = (function(settings) {
               }
             },
 
-            //Folders
             folders() {
 
               if (!message_id) {
@@ -218,7 +206,6 @@ module.exports = (function(settings) {
               }
             },
 
-            //Headers
             headers() {
 
               if (!message_id) {
@@ -238,7 +225,6 @@ module.exports = (function(settings) {
               }
             },
 
-            //Source
             source() {
 
               if (!message_id) {
@@ -252,7 +238,6 @@ module.exports = (function(settings) {
               }
             },
 
-            //Thread
             thread() {
 
               if (!message_id) {
@@ -268,7 +253,6 @@ module.exports = (function(settings) {
           }
         },
 
-        //Sources
         sources(label) {
 
           if (!account_id) {
@@ -282,7 +266,6 @@ module.exports = (function(settings) {
             post: _callService.post.bind(_callService, resource),
             delete: _callService.delete.bind(_callService, resource),
 
-            //Folders
             folders(folder) {
 
               if (!label) {
@@ -296,7 +279,6 @@ module.exports = (function(settings) {
                 put: _callService.put.bind(_callService, resource),
                 delete: _callService.delete.bind(_callService, resource),
 
-                //Expunge
                 expunge() {
 
                   if (!folder) {
@@ -310,7 +292,6 @@ module.exports = (function(settings) {
                   }
                 },
 
-                //Messages
                 messages(async_job_id) {
 
                   if (!folder) {
@@ -328,7 +309,6 @@ module.exports = (function(settings) {
           }
         },
 
-        //Sync
         sync() {
 
           if (!account_id) {
@@ -343,7 +323,6 @@ module.exports = (function(settings) {
           }
         },
 
-        //Webhooks
         webhooks(webhook_id) {
 
           if (!account_id) {
@@ -361,7 +340,6 @@ module.exports = (function(settings) {
       }
     }
 
-    //Connect Tokens
     connect_tokens(token) {
       var resource = token ? 'connect_tokens/' + encodeURIComponent(token) + '/' : 'connect_tokens/'
 
@@ -372,14 +350,12 @@ module.exports = (function(settings) {
       }
     }
 
-    //Discovery
     discovery() {
       return {
         get: _callService.get.bind(_callService, 'discovery/')
       }
     }
 
-    //OAuth Providers
     oauth_providers(key) {
       var resource = key ? 'oauth_providers/' + encodeURIComponent(key) + '/' : 'oauth_providers/'
 

--- a/lib/2.0/index.js
+++ b/lib/2.0/index.js
@@ -24,9 +24,9 @@ module.exports = (function(settings) {
       var resource = account_id ? 'accounts/' + encodeURIComponent(account_id) + '/' : 'accounts/'
 
       return {
-        get: _callService.get.bind(this, resource),
-        post: _callService.post.bind(this, resource),
-        delete: _callService.delete.bind(this, resource),
+        get: _callService.get.bind(_callService, resource),
+        post: _callService.post.bind(_callService, resource),
+        delete: _callService.delete.bind(_callService, resource),
 
         //Connect Tokens
         connect_tokens(token) {
@@ -38,9 +38,9 @@ module.exports = (function(settings) {
           resource += token ? 'connect_tokens/' + encodeURIComponent(token) + '/' : 'connect_tokens/'
 
           return {
-            get: _callService.get.bind(this, resource),
-            post: _callService.post.bind(this, resource),
-            delete: _callService.delete.bind(this, resource)
+            get: _callService.get.bind(_callService, resource),
+            post: _callService.post.bind(_callService, resource),
+            delete: _callService.delete.bind(_callService, resource)
           }
         },
 
@@ -54,7 +54,7 @@ module.exports = (function(settings) {
           resource += email ? 'contacts/' + encodeURIComponent(email) + '/' : 'contacts/'
 
           return {
-            get: _callService.get.bind(this, resource),
+            get: _callService.get.bind(_callService, resource),
 
             //Files
             files() {
@@ -64,7 +64,7 @@ module.exports = (function(settings) {
               }
 
               return {
-                get: _callService.get.bind(this, resource + 'files/')
+                get: _callService.get.bind(_callService, resource + 'files/')
               }
             },
 
@@ -76,7 +76,7 @@ module.exports = (function(settings) {
               }
 
               return {
-                get: _callService.get.bind(this, resource + 'messages/')
+                get: _callService.get.bind(_callService, resource + 'messages/')
               }
             },
 
@@ -88,7 +88,7 @@ module.exports = (function(settings) {
               }
 
               return {
-                get: _callService.get.bind(this, resource + 'threads/')
+                get: _callService.get.bind(_callService, resource + 'threads/')
               }
             },
           }
@@ -104,9 +104,9 @@ module.exports = (function(settings) {
           resource += email ? 'email_addresses/' + encodeURIComponent(email) + '/' : 'email_addresses/'
 
           return {
-            get: _callService.get.bind(this, resource),
-            post: _callService.post.bind(this, resource),
-            delete: _callService.delete.bind(this, resource)
+            get: _callService.get.bind(_callService, resource),
+            post: _callService.post.bind(_callService, resource),
+            delete: _callService.delete.bind(_callService, resource)
           }
         },
 
@@ -120,7 +120,7 @@ module.exports = (function(settings) {
           resource += file_id ? 'files/' + encodeURIComponent(file_id) + '/' : 'files/'
 
           return {
-            get: _callService.get.bind(this, resource),
+            get: _callService.get.bind(_callService, resource),
 
             //Content is a special snowflake with special get functions
             content() {
@@ -153,7 +153,7 @@ module.exports = (function(settings) {
               resource += 'related/'
 
               return {
-                get: _callService.get.bind(this, resource)
+                get: _callService.get.bind(_callService, resource)
               }
             },
           }
@@ -169,9 +169,9 @@ module.exports = (function(settings) {
           resource += message_id ? 'messages/' + encodeURIComponent(message_id) + '/' : 'messages/'
 
           return {
-            get: _callService.get.bind(this, resource),
-            post: _callService.post.bind(this, resource),
-            delete: _callService.delete.bind(this, resource),
+            get: _callService.get.bind(_callService, resource),
+            post: _callService.post.bind(_callService, resource),
+            delete: _callService.delete.bind(_callService, resource),
 
             //Body
             body() {
@@ -183,7 +183,7 @@ module.exports = (function(settings) {
               resource += 'body/'
 
               return {
-                get: _callService.get.bind(this, resource)
+                get: _callService.get.bind(_callService, resource)
               }
             },
 
@@ -197,8 +197,8 @@ module.exports = (function(settings) {
               resource += 'flags/'
 
               return {
-                get: _callService.get.bind(this, resource),
-                post: _callService.post.bind(this, resource)
+                get: _callService.get.bind(_callService, resource),
+                post: _callService.post.bind(_callService, resource)
               }
             },
 
@@ -212,9 +212,9 @@ module.exports = (function(settings) {
               resource += 'folders/'
 
               return {
-                get: _callService.get.bind(this, resource),
-                post: _callService.post.bind(this, resource),
-                put: _callService.put.bind(this, resource)
+                get: _callService.get.bind(_callService, resource),
+                post: _callService.post.bind(_callService, resource),
+                put: _callService.put.bind(_callService, resource)
               }
             },
 
@@ -248,7 +248,7 @@ module.exports = (function(settings) {
               resource += 'source/'
 
               return {
-                get: _callService.getRaw.bind(this, resource)
+                get: _callService.getRaw.bind(_callService, resource)
               }
             },
 
@@ -262,7 +262,7 @@ module.exports = (function(settings) {
               resource += 'thread/'
 
               return {
-                get: _callService.get.bind(this, resource)
+                get: _callService.get.bind(_callService, resource)
               }
             },
           }
@@ -278,9 +278,9 @@ module.exports = (function(settings) {
           resource += label ? 'sources/' + encodeURIComponent(label) + '/' : 'sources/'
 
           return {
-            get: _callService.get.bind(this, resource),
-            post: _callService.post.bind(this, resource),
-            delete: _callService.delete.bind(this, resource),
+            get: _callService.get.bind(_callService, resource),
+            post: _callService.post.bind(_callService, resource),
+            delete: _callService.delete.bind(_callService, resource),
 
             //Folders
             folders(folder) {
@@ -292,9 +292,9 @@ module.exports = (function(settings) {
               resource += folder ? 'folders/' + encodeURIComponent(folder) + '/' : 'folders/'
 
               return {
-                get: _callService.get.bind(this, resource),
-                put: _callService.put.bind(this, resource),
-                delete: _callService.delete.bind(this, resource),
+                get: _callService.get.bind(_callService, resource),
+                put: _callService.put.bind(_callService, resource),
+                delete: _callService.delete.bind(_callService, resource),
 
                 //Expunge
                 expunge() {
@@ -306,7 +306,7 @@ module.exports = (function(settings) {
                   resource += 'expunge/'
 
                   return {
-                    post: _callService.post.bind(this, resource)
+                    post: _callService.post.bind(_callService, resource)
                   }
                 },
 
@@ -320,7 +320,7 @@ module.exports = (function(settings) {
                   resource += async_job_id ? 'messages/' + encodeURIComponent(async_job_id) + '/' : 'messages/'
 
                   return {
-                    get: _callService.get.bind(this, resource)
+                    get: _callService.get.bind(_callService, resource)
                   }
                 }
               }
@@ -338,8 +338,8 @@ module.exports = (function(settings) {
           resource += 'sync/'
 
           return {
-            get: _callService.get.bind(this, resource),
-            post: _callService.post.bind(this, resource)
+            get: _callService.get.bind(_callService, resource),
+            post: _callService.post.bind(_callService, resource)
           }
         },
 
@@ -353,9 +353,9 @@ module.exports = (function(settings) {
           resource += webhook_id ? 'webhooks/' + encodeURIComponent(webhook_id) + '/' : 'webhooks/'
 
           return {
-            get: _callService.get.bind(this, resource),
-            post: _callService.post.bind(this, resource),
-            delete: _callService.delete.bind(this, resource)
+            get: _callService.get.bind(_callService, resource),
+            post: _callService.post.bind(_callService, resource),
+            delete: _callService.delete.bind(_callService, resource)
           }
         }
       }
@@ -366,16 +366,16 @@ module.exports = (function(settings) {
       var resource = token ? 'connect_tokens/' + encodeURIComponent(token) + '/' : 'connect_tokens/'
 
       return {
-        get: _callService.get.bind(this, resource),
-        post: _callService.post.bind(this, resource),
-        delete: _callService.delete.bind(this, resource)
+        get: _callService.get.bind(_callService, resource),
+        post: _callService.post.bind(_callService, resource),
+        delete: _callService.delete.bind(_callService, resource)
       }
     }
 
     //Discovery
     discovery() {
       return {
-        get: _callService.get.bind(this, 'discovery/')
+        get: _callService.get.bind(_callService, 'discovery/')
       }
     }
 
@@ -384,9 +384,9 @@ module.exports = (function(settings) {
       var resource = key ? 'oauth_providers/' + encodeURIComponent(key) + '/' : 'oauth_providers/'
 
       return {
-        get: _callService.get.bind(this, resource),
-        post: _callService.post.bind(this, resource),
-        delete: _callService.delete.bind(this, resource)
+        get: _callService.get.bind(_callService, resource),
+        post: _callService.post.bind(_callService, resource),
+        delete: _callService.delete.bind(_callService, resource)
       }
     }
 

--- a/lib/call-service.js
+++ b/lib/call-service.js
@@ -8,7 +8,6 @@ module.exports = (function(version, settings) {
   // Private Members
   var apiBase = "https://api.context.io/"
   var oauth
-  var options
 
   // Public Constructor
   return new class {
@@ -29,11 +28,6 @@ module.exports = (function(version, settings) {
         consumer_secret: settings.secret
       }
 
-      options = {
-        oauth: oauth,
-        "User-Agent": 'Context.IO Node Client v0.6.0'
-      }
-
       //Super secret testing mock function
       //Returns a promise that resolves to the data being passed to request-promise
       if(settings.testing === true) {
@@ -45,70 +39,89 @@ module.exports = (function(version, settings) {
 
     }
 
+    sendRequest(options) {
+      options.url = apiBase + options.url
+      options.oauth = oauth
+      options["User-Agent"] = 'Context.IO Node Client v0.6.0'
+      return request(options)
+    }
+
     //HTTP Functions always return a promise, and the response will be parsed as JSON except for getFile() and getRaw().
 
     //Main get funciton. Params are added as querystring params.
     get(url, params) {
-      options.url = apiBase + url
-      options.qs = params
+      var options = {
+        url: url,
+        qs: params
+      }
 
-      return request(options).then(function(body) {
+      return this.sendRequest(options).then(function(body) {
         return JSON.parse(body)
       })
     }
 
     //File get, returns headers and the body.
     getFile(url, params) {
-      options.url = apiBase + url
-      options.qs = params
-      options.resolveWithFullResponse = true
+      var options = {
+        url: url,
+        qs: params,
+        resolveWithFullResponse: true
+      }
 
-      return request(options).then(function(res) {
+      return this.sendRequest(options).then(function(res) {
         return { headers: res.headers, body: res.body }
       })
     }
 
     //Return raw response, no parsing.
     getRaw(url, params) {
-      options.url = apiBase + url
-      options.qs = params
+      var options = {
+        url: url,
+        qs: params
+      }
 
-      return request(options).then(function(body) {
+      return this.sendRequest(options).then(function(body) {
         return body
       })
     }
 
     //Post. Params are added as querystring params. Body is sent as application/x-www-form-urlencoded
     post(url, body, params) {
-      options.url = apiBase + url
-      options.method = 'POST'
-      options.qs = params
-      options.form = body
+      var options = {
+        url: url,
+        method: 'POST',
+        qs: params,
+        form: body
+      }
 
-      return request(options).then(function(body) {
+      return this.sendRequest(options).then(function(body) {
         return JSON.parse(body)
       })
     }
 
     //Put. Params are added as querystring params. Body is sent as application/x-www-form-urlencoded
     put(url, body, params) {
-      options.url = apiBase + url
-      options.method = 'PUT'
-      options.qs = params
-      options.form = body
+      var options = {
+        url: url,
+        method: 'PUT',
+        qs: params,
+        form: body
+      }
 
-      return request(options).then(function(body) {
+      return this.sendRequest(options).then(function(body) {
         return JSON.parse(body)
       })
     }
 
     //Delete. Params are added as querystring params.
     delete(url, params) {
-      options.url = apiBase + url
-      options.method = 'DELETE'
-      options.qs = params
-
-      return request(options).then(function(body) {
+      var options = {
+        url: url,
+        method: 'DELETE',
+        qs: params
+      }
+      
+      return this.sendRequest(options).then(function(body) {
         return JSON.parse(body)
       })
     }

--- a/lib/lite/index.js
+++ b/lib/lite/index.js
@@ -25,9 +25,9 @@ module.exports = (function(settings) {
       var resource = user_id ? 'users/' + encodeURIComponent(user_id) + '/' : 'users/'
 
       return {
-        get: _callService.get.bind(this, resource),
-        post: _callService.post.bind(this, resource),
-        delete: _callService.delete.bind(this, resource),
+        get: _callService.get.bind(_callService, resource),
+        post: _callService.post.bind(_callService, resource),
+        delete: _callService.delete.bind(_callService, resource),
 
         //Connect Tokens
         connect_tokens(token) {
@@ -39,9 +39,9 @@ module.exports = (function(settings) {
           resource += token ? 'connect_tokens/' + encodeURIComponent(token) + '/' : 'connect_tokens/'
 
           return {
-            get: _callService.get.bind(this, resource),
-            post: _callService.post.bind(this, resource),
-            delete: _callService.delete.bind(this, resource)
+            get: _callService.get.bind(_callService, resource),
+            post: _callService.post.bind(_callService, resource),
+            delete: _callService.delete.bind(_callService, resource)
           }
         },
 
@@ -55,9 +55,9 @@ module.exports = (function(settings) {
           resource += label ? 'email_accounts/' + encodeURIComponent(label) + '/' : 'email_accounts/'
 
           return {
-            get: _callService.get.bind(this, resource),
-            post: _callService.post.bind(this, resource),
-            delete: _callService.delete.bind(this, resource),
+            get: _callService.get.bind(_callService, resource),
+            post: _callService.post.bind(_callService, resource),
+            delete: _callService.delete.bind(_callService, resource),
 
             //Folders
             folders(folder) {
@@ -69,8 +69,8 @@ module.exports = (function(settings) {
               resource += folder ? 'folders/' + encodeURIComponent(folder) + '/' : 'folders/'
 
               return {
-                get: _callService.get.bind(this, resource),
-                post: _callService.post.bind(this, resource),
+                get: _callService.get.bind(_callService, resource),
+                post: _callService.post.bind(_callService, resource),
 
                 //Messages
                 messages(message_id) {
@@ -82,8 +82,8 @@ module.exports = (function(settings) {
                   resource += message_id ? 'messages/' + encodeURIComponent(message_id) + '/' : 'messages/'
 
                   return {
-                    get: _callService.get.bind(this, resource),
-                    put: _callService.put.bind(this, resource),
+                    get: _callService.get.bind(_callService, resource),
+                    put: _callService.put.bind(_callService, resource),
 
                     //Attachements
                     attachements(attachment_id) {
@@ -95,7 +95,7 @@ module.exports = (function(settings) {
                       resource += attachment_id ? 'attachements/' + encodeURIComponent(attachment_id) + '/' : 'messages/'
 
                       return {
-                        get: _callService.get.bind(this, resource)
+                        get: _callService.get.bind(_callService, resource)
                       }
                     },
 
@@ -109,7 +109,7 @@ module.exports = (function(settings) {
                       resource += 'body/'
 
                       return {
-                        get: _callService.get.bind(this, resource)
+                        get: _callService.get.bind(_callService, resource)
                       }
                     },
 
@@ -123,7 +123,7 @@ module.exports = (function(settings) {
                       resource += 'flags/'
 
                       return {
-                        get: _callService.get.bind(this, resource)
+                        get: _callService.get.bind(_callService, resource)
                       }
                     },
 
@@ -137,7 +137,7 @@ module.exports = (function(settings) {
                       resource += 'headers/'
 
                       return {
-                        get: _callService.get.bind(this, resource)
+                        get: _callService.get.bind(_callService, resource)
                       }
                     },
 
@@ -151,7 +151,7 @@ module.exports = (function(settings) {
                       resource += 'raw/'
 
                       return {
-                        get: _callService.get.bind(this, resource)
+                        get: _callService.get.bind(_callService, resource)
                       }
                     },
 
@@ -165,8 +165,8 @@ module.exports = (function(settings) {
                       resource += 'read/'
 
                       return {
-                        post: _callService.post.bind(this, resource),
-                        delete: _callService.delete.bind(this, resource)
+                        post: _callService.post.bind(_callService, resource),
+                        delete: _callService.delete.bind(_callService, resource)
                       }
                     }
                   }
@@ -186,9 +186,9 @@ module.exports = (function(settings) {
           resource += webhook_id ? 'webhooks/' + encodeURIComponent(webhook_id) + '/' : 'webhooks/'
 
           return {
-            get: _callService.get.bind(this, resource),
-            post: _callService.post.bind(this, resource),
-            delete: _callService.delete.bind(this, resource)
+            get: _callService.get.bind(_callService, resource),
+            post: _callService.post.bind(_callService, resource),
+            delete: _callService.delete.bind(_callService, resource)
           }
         }
       }
@@ -199,16 +199,16 @@ module.exports = (function(settings) {
       var resource = token ? 'connect_tokens/' + encodeURIComponent(token) + '/' : 'connect_tokens/'
 
       return {
-        get: _callService.get.bind(this, resource),
-        post: _callService.post.bind(this, resource),
-        delete: _callService.delete.bind(this, resource)
+        get: _callService.get.bind(_callService, resource),
+        post: _callService.post.bind(_callService, resource),
+        delete: _callService.delete.bind(_callService, resource)
       }
     }
 
     //Discovery
     discovery() {
       return {
-        get: _callService.get.bind(this, 'discovery/')
+        get: _callService.get.bind(_callService, 'discovery/')
       }
     }
 
@@ -217,9 +217,9 @@ module.exports = (function(settings) {
       var resource = key ? 'oauth_providers/' + encodeURIComponent(key) + '/' : 'oauth_providers/'
 
       return {
-        get: _callService.get.bind(this, resource),
-        post: _callService.post.bind(this, resource),
-        delete: _callService.delete.bind(this, resource)
+        get: _callService.get.bind(_callService, resource),
+        post: _callService.post.bind(_callService, resource),
+        delete: _callService.delete.bind(_callService, resource)
       }
     }
 

--- a/lib/lite/index.js
+++ b/lib/lite/index.js
@@ -92,6 +92,12 @@ module.exports = (function(settings) {
                         get: _callService.get.bind(_callService, resource)
                       }
                     },
+                    
+                    // This is the correct english spelling of 'attachments'
+                    // TODO: change 'attachements' to 'attachments' in api
+                    attachments(attachment_id) {
+                      return this.attachements(attachment_id)
+                    },
 
                     body() {
 

--- a/lib/lite/index.js
+++ b/lib/lite/index.js
@@ -20,7 +20,6 @@ module.exports = (function(settings) {
       _callService = new callService('lite', settings)
     }
 
-    //Users
     users(user_id) {
       var resource = user_id ? 'users/' + encodeURIComponent(user_id) + '/' : 'users/'
 
@@ -29,7 +28,6 @@ module.exports = (function(settings) {
         post: _callService.post.bind(_callService, resource),
         delete: _callService.delete.bind(_callService, resource),
 
-        //Connect Tokens
         connect_tokens(token) {
 
           if (!user_id) {
@@ -45,7 +43,6 @@ module.exports = (function(settings) {
           }
         },
 
-        //Email Accounts
         email_accounts(label) {
 
           if (!user_id) {
@@ -59,7 +56,6 @@ module.exports = (function(settings) {
             post: _callService.post.bind(_callService, resource),
             delete: _callService.delete.bind(_callService, resource),
 
-            //Folders
             folders(folder) {
 
               if (!label) {
@@ -72,7 +68,6 @@ module.exports = (function(settings) {
                 get: _callService.get.bind(_callService, resource),
                 post: _callService.post.bind(_callService, resource),
 
-                //Messages
                 messages(message_id) {
 
                   if (!folder) {
@@ -85,7 +80,6 @@ module.exports = (function(settings) {
                     get: _callService.get.bind(_callService, resource),
                     put: _callService.put.bind(_callService, resource),
 
-                    //Attachements
                     attachements(attachment_id) {
 
                       if (!message_id) {
@@ -99,7 +93,6 @@ module.exports = (function(settings) {
                       }
                     },
 
-                    //Body
                     body() {
 
                       if (!message_id) {
@@ -113,7 +106,6 @@ module.exports = (function(settings) {
                       }
                     },
 
-                    //Flags
                     flags() {
 
                       if (!message_id) {
@@ -127,7 +119,6 @@ module.exports = (function(settings) {
                       }
                     },
 
-                    //Headers
                     headers() {
 
                       if (!message_id) {
@@ -141,7 +132,6 @@ module.exports = (function(settings) {
                       }
                     },
 
-                    //Raw
                     raw() {
 
                       if (!message_id) {
@@ -155,7 +145,6 @@ module.exports = (function(settings) {
                       }
                     },
 
-                    //Read
                     read() {
 
                       if (!message_id) {
@@ -176,7 +165,6 @@ module.exports = (function(settings) {
           }
         },
 
-        //Webhooks
         webhooks(webhook_id) {
 
           if (!user_id) {
@@ -194,7 +182,6 @@ module.exports = (function(settings) {
       }
     }
 
-    //Connect Tokens
     connect_tokens(token) {
       var resource = token ? 'connect_tokens/' + encodeURIComponent(token) + '/' : 'connect_tokens/'
 
@@ -205,14 +192,12 @@ module.exports = (function(settings) {
       }
     }
 
-    //Discovery
     discovery() {
       return {
         get: _callService.get.bind(_callService, 'discovery/')
       }
     }
 
-    //OAuth Providers
     oauth_providers(key) {
       var resource = key ? 'oauth_providers/' + encodeURIComponent(key) + '/' : 'oauth_providers/'
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "contextio",
   "description": "Official Node.js client library for the Context.IO Email API",
+  "scripts": {
+    "test": "jasmine"
+  },
   "keywords": [
     "email",
     "ContextIO",


### PR DESCRIPTION
PR includes:
- Fixes bug: sometimes messages.get() would make a POST request instead of GET, because request options linger.
- renamed "attachements" to "attachments" as the correct spelling. But it's backward compatible.
- `npm test` to run tests.
